### PR TITLE
Spell checker whitelist

### DIFF
--- a/shared/.pronto_spell.pws
+++ b/shared/.pronto_spell.pws
@@ -166,6 +166,7 @@ elsif
 emmet
 endcomment
 endif
+endunless
 enqueue
 enqueuing
 entrypoints
@@ -278,6 +279,7 @@ klaviyo
 komar
 komiko
 kryvoruchko
+labelledby
 laquo
 lastname
 lazorenko
@@ -486,6 +488,7 @@ srcset
 stacey
 stackoverflow
 storages
+strftime
 stylelint
 stylesheet
 stylesheets


### PR DESCRIPTION

`labelledby`
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-labelledby_attribute