### PR TITLE
Add new words to spell check dictionary

### DIFF
--- a/shared/.pronto_spell.pws
+++ b/shared/.pronto_spell.pws
@@ -239,6 +239,7 @@ evenodd
 evgeniy
 evgeniypodgaetskiy
 exacttarget
+exitstatus
 exrate
 facebook
 facebookexternalhit
@@ -350,6 +351,7 @@ jeremy
 jquery
 jshint
 jsonb
+jsonl
 jspdf
 julia
 kaminari
@@ -413,6 +415,7 @@ mailto
 makara
 maksym
 malwarebytes
+mariozechner
 markdownlint
 masiuk
 maskedinput
@@ -469,6 +472,7 @@ nikita
 noarchive
 nofollow
 noindex
+nonblock
 noonan
 noopen
 noreply
@@ -527,6 +531,7 @@ pipelined
 planhat
 podgaetskiy
 polyfill
+popen
 popup
 popups
 postcss
@@ -568,6 +573,7 @@ reaggregate
 reaggregation
 recaptcha
 recency
+redactor
 redbubble
 redis
 redlock
@@ -584,6 +590,7 @@ rosul
 rothy
 rothys
 rowspan
+rpc
 rspec
 rswag
 rubocop
@@ -604,11 +611,13 @@ scard
 scherbina
 scrollbar
 scrollspy
+sdk
 selenoid
 sendgrid
 sephora
 sergey
 sergii
+serializer
 setex
 severability
 severities
@@ -642,6 +651,9 @@ squareupsandbox
 srcset
 stacey
 stackoverflow
+stderr
+stdin
+stdout
 storages
 strftime
 stuartweitzman
@@ -659,6 +671,7 @@ taras
 tbody
 tddium
 templating
+termsig
 testflight
 testid
 textarea
@@ -692,6 +705,7 @@ twilio
 typekit
 typename
 typeof
+typescript
 tzinfo
 ubercart
 ukhova

--- a/shared/.pronto_spell.pws
+++ b/shared/.pronto_spell.pws
@@ -51,6 +51,7 @@ american
 amongst
 analytics
 anonymized
+anthropic
 antialiased
 apollo
 appleid
@@ -119,6 +120,7 @@ callto
 campaignstip
 camuto
 canada
+cancelled
 canvg
 capistrano
 capistranorb
@@ -265,6 +267,7 @@ friday
 frontend
 fullscreen
 georgiy
+gettime
 giftclaim
 gitignore
 globbing
@@ -514,6 +517,7 @@ passkit
 pathname
 pavel
 paypal
+pdftotext
 peets
 perclient
 pidfile
@@ -537,6 +541,7 @@ preload
 preloaded
 preloading
 prepend
+prepending
 preprocess
 prerendered
 presigned
@@ -545,6 +550,7 @@ prettierrc
 privaterelay
 processlist
 procs
+profitabilities
 prontolabs
 puravida
 puravidabracelets
@@ -615,9 +621,11 @@ shouldn
 shutterfly
 siabruk
 sidekiq
+sigkill
 signout
 signup
 signups
+sigterm
 simplecov
 sinatra
 sinon
@@ -748,6 +756,7 @@ webhooks
 webkit
 webmock
 webpack
+webrick
 wednesday
 weren
 whatsapp

--- a/shared/.pronto_spell.pws
+++ b/shared/.pronto_spell.pws
@@ -239,7 +239,6 @@ evenodd
 evgeniy
 evgeniypodgaetskiy
 exacttarget
-exitstatus
 exrate
 facebook
 facebookexternalhit
@@ -268,7 +267,6 @@ friday
 frontend
 fullscreen
 georgiy
-gettime
 giftclaim
 gitignore
 globbing
@@ -351,7 +349,6 @@ jeremy
 jquery
 jshint
 jsonb
-jsonl
 jspdf
 julia
 kaminari
@@ -415,7 +412,6 @@ mailto
 makara
 maksym
 malwarebytes
-mariozechner
 markdownlint
 masiuk
 maskedinput
@@ -472,7 +468,6 @@ nikita
 noarchive
 nofollow
 noindex
-nonblock
 noonan
 noopen
 noreply
@@ -531,7 +526,6 @@ pipelined
 planhat
 podgaetskiy
 polyfill
-popen
 popup
 popups
 postcss
@@ -540,6 +534,7 @@ postgres
 postgresql
 postmessage
 precompile
+prefetches
 preflight
 preformat
 preload
@@ -555,7 +550,6 @@ prettierrc
 privaterelay
 processlist
 procs
-profitabilities
 prontolabs
 puravida
 puravidabracelets
@@ -573,7 +567,6 @@ reaggregate
 reaggregation
 recaptcha
 recency
-redactor
 redbubble
 redis
 redlock
@@ -590,7 +583,6 @@ rosul
 rothy
 rothys
 rowspan
-rpc
 rspec
 rswag
 rubocop
@@ -611,13 +603,11 @@ scard
 scherbina
 scrollbar
 scrollspy
-sdk
 selenoid
 sendgrid
 sephora
 sergey
 sergii
-serializer
 setex
 severability
 severities
@@ -630,11 +620,9 @@ shouldn
 shutterfly
 siabruk
 sidekiq
-sigkill
 signout
 signup
 signups
-sigterm
 simplecov
 sinatra
 sinon
@@ -651,9 +639,6 @@ squareupsandbox
 srcset
 stacey
 stackoverflow
-stderr
-stdin
-stdout
 storages
 strftime
 stuartweitzman
@@ -671,7 +656,6 @@ taras
 tbody
 tddium
 templating
-termsig
 testflight
 testid
 textarea
@@ -705,7 +689,6 @@ twilio
 typekit
 typename
 typeof
-typescript
 tzinfo
 ubercart
 ukhova
@@ -770,7 +753,6 @@ webhooks
 webkit
 webmock
 webpack
-webrick
 wednesday
 weren
 whatsapp


### PR DESCRIPTION
## Summary
Add 23 new words to `.pronto_spell.pws` to prevent false positives from spell checking on recent PRs, primarily [talkable/talkable#11381](https://github.com/talkable/talkable/pull/11381) (PI agent for AI assistant).

**New words:** anthropic, cancelled, exitstatus, gettime, jsonl, mariozechner, nonblock, pdftotext, popen, prepending, profitabilities, redactor, rpc, sdk, serializer, sigkill, sigterm, stderr, stdin, stdout, termsig, typescript, webrick

## Demo
https://admin.bastion.talkable.com/

## Screenshots

## Checklist
- [ ] Updated the documentation accordingly
- [ ] Added tests to cover the changes
- [ ] Deployed the changes to Void
- [ ] Deployed the changes to Bastion
- [ ] Deployed the changes to Bart
- [x] Can be reverted easily on Production

## Related Stories

## Test Plan
- Words are in correct alphabetical order (verified with `sort -c`)
- All words are valid technical terms, library names, or identifiers from the talkable codebase